### PR TITLE
Localize headers on "show" pages

### DIFF
--- a/src/Siwapp/EstimateBundle/Resources/views/Estimate/show.html.twig
+++ b/src/Siwapp/EstimateBundle/Resources/views/Estimate/show.html.twig
@@ -27,7 +27,7 @@
 
 
 {% block invoice_label %}
-  <h2>Estimate {{ entity.label() }}</h2>
+  <h2>{% trans %}estimate.estimate{% endtrans %} {{ entity.label() }}</h2>
   <ul class="list-inline list-unstyled">
     <li>
       <span class="label {{ entity.statusString }}">{{ ('estimate.' ~ entity.statusString)|trans }}</span>

--- a/src/Siwapp/InvoiceBundle/Resources/views/Invoice/show.html.twig
+++ b/src/Siwapp/InvoiceBundle/Resources/views/Invoice/show.html.twig
@@ -16,7 +16,7 @@
 
 
 {% block invoice_label %}
-  <h2>Invoice {{ entity.label() }}</h2>
+  <h2>{% trans %}invoice.invoice{% endtrans %} {{ entity.label() }}</h2>
   <ul id="invoice-like-status" class="list-unstyled">
     <li>
       <span class="label {{ entity.statusString }}">{{ ('invoice.' ~ entity.statusString)|trans }}</span>


### PR DESCRIPTION
Currently the `<h2>` headers are only shown translated for open invoices/estimates, not in closed ones. This fixes it.