### PR TITLE
MIME Multipart emails (better deliverability)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "twig/extensions": "^1.3",
         "knplabs/knp-paginator-bundle": "^2.5",
         "friendsofsymfony/user-bundle": "~2.0@dev",
-        "knplabs/knp-snappy-bundle": "^1.4"
+        "knplabs/knp-snappy-bundle": "^1.4",
+        "soundasleep/html2text": "~0.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.4",

--- a/src/Siwapp/EstimateBundle/Controller/EstimateController.php
+++ b/src/Siwapp/EstimateBundle/Controller/EstimateController.php
@@ -412,6 +412,7 @@ class EstimateController extends AbstractInvoiceController
             ->setFrom($configRepo->get('company_email'), $configRepo->get('company_name'))
             ->setTo($estimate->getCustomerEmail(), $estimate->getCustomerName())
             ->setBody($html, 'text/html')
+            ->addPart($text, 'text/plain')
             ->attach($attachment);
 
         return $message;

--- a/src/Siwapp/EstimateBundle/Controller/EstimateController.php
+++ b/src/Siwapp/EstimateBundle/Controller/EstimateController.php
@@ -403,6 +403,7 @@ class EstimateController extends AbstractInvoiceController
             'estimate'  => $estimate,
             'settings' => $em->getRepository('SiwappConfigBundle:Property')->getAll(),
         ));
+        $text = Html2Text\Html2Text::convert($html);
         $pdf = $this->getPdf($html);
         $attachment = new \Swift_Attachment($pdf, $estimate->getId().'.pdf', 'application/pdf');
         $subject = '[' . $this->get('translator')->trans('estimate.estimate', [], 'SiwappEstimateBundle') . ': ' . $estimate->label() . ']';

--- a/src/Siwapp/InvoiceBundle/Controller/InvoiceController.php
+++ b/src/Siwapp/InvoiceBundle/Controller/InvoiceController.php
@@ -443,6 +443,7 @@ class InvoiceController extends AbstractInvoiceController
             ->setFrom($configRepo->get('company_email'), $configRepo->get('company_name'))
             ->setTo($invoice->getCustomerEmail(), $invoice->getCustomerName())
             ->setBody($html, 'text/html')
+            ->addPart($text, 'text/plain')
             ->attach($attachment);
 
         return $message;

--- a/src/Siwapp/InvoiceBundle/Controller/InvoiceController.php
+++ b/src/Siwapp/InvoiceBundle/Controller/InvoiceController.php
@@ -434,6 +434,7 @@ class InvoiceController extends AbstractInvoiceController
             'invoice'  => $invoice,
             'settings' => $em->getRepository('SiwappConfigBundle:Property')->getAll(),
         ));
+        $text = Html2Text\Html2Text::convert($html);
         $pdf = $this->getPdf($html);
         $attachment = new \Swift_Attachment($pdf, $invoice->getId().'.pdf', 'application/pdf');
         $subject = '[' . $this->get('translator')->trans('invoice.invoice', [], 'SiwappInvoiceBundle') . ': ' . $invoice->label() . ']';


### PR DESCRIPTION
Currently, invoices and estimates are sent by email as html only.

This PR adds a text version generator (using [html2text](https://github.com/soundasleep/html2text)) and formats emails as html+text multipart, using Swift Mailer native feature.

This improvement will make invoices work on email clients with html disabled, and will also significantly increase deliverability (as sending pure html is [penalized by spam filters](https://wiki.apache.org/spamassassin/Rules/MIME_HTML_ONLY)). Given we are sending invoices, it is important to reduce the chance of them going to spam folder, unnoticed by clients.

https://litmus.com/blog/reach-more-people-and-improve-your-spam-score-why-multi-part-email-is-important