### PR TITLE
Disallow search engines indexing

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -2,3 +2,4 @@
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
 User-agent: *
+Disallow: /


### PR DESCRIPTION
As this is an internal use app by design, not supposed to be accessed by the public, I think it would make sense to prevent it from being publicly indexed by search engines, instead of allowing so in robots.txt as it's currently the case.